### PR TITLE
Remove the last forward-slash from 'BASE_URL'

### DIFF
--- a/nba_py/__init__.py
+++ b/nba_py/__init__.py
@@ -10,7 +10,7 @@ except ImportError:
 
 # Constants
 TODAY = datetime.today()
-BASE_URL = 'http://stats.nba.com/stats/{endpoint}/'
+BASE_URL = 'http://stats.nba.com/stats/{endpoint}'
 HEADERS = {'user-agent': ('Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_5) '
                           'AppleWebKit/537.36 (KHTML, like Gecko) '
                           'Chrome/45.0.2454.101 Safari/537.36'),


### PR DESCRIPTION
Removing the forward slash that originally came after '{endpoint}' fixes 400 code request errors. Using this altered base, classes that previously did not function (e.g., TeamList and PlayerList) once again function
